### PR TITLE
test(staged): add staged tests infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3217,8 +3217,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3357,7 +3356,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3483,8 +3481,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {
+      "src/index.*": "<rootDir>/src/aurelia-tree.ts",
+      ".*src/styles.css": "<rootDir>/dist/commonjs/styles.css",
+      ".*test/unit/src/(.*)": "<rootDir>/src/$1.ts",
       "(test\\\\unit\\\\)aurelia-(.*)": "<rootDir>/node_modules/aurelia-$2",
       "^.+\\.(css)$": "<rootDir>/test/jest-css-stub.js"
     },

--- a/src/au-tree-root.html
+++ b/src/au-tree-root.html
@@ -1,6 +1,5 @@
 <template class="au-tree"
           tabindex="0">
-  <require from="./styles.css"></require>
 
   <au-tree-node extra-classes="au-tree__root"
                 root.bind="$this"

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,0 +1,16 @@
+import { Aurelia, PLATFORM, ViewLocator, Origin } from "aurelia-framework";
+
+export function bootstrapPlugin(component) {
+  component.bootstrap((aurelia: Aurelia) => {
+    ViewLocator.prototype.convertOriginToViewUrl = (origin: Origin): string => {
+      let moduleId = origin.moduleId;
+
+      return moduleId.startsWith("src/")
+        ? `../../${moduleId}.html`
+        : `${moduleId}.html`;
+    };
+    
+    aurelia.use.standardConfiguration()
+      .feature(PLATFORM.moduleName("src"));
+  });
+}

--- a/test/unit/mocks/tree-vm.html
+++ b/test/unit/mocks/tree-vm.html
@@ -1,0 +1,3 @@
+<template>
+
+</template>

--- a/test/unit/mocks/tree-vm.ts
+++ b/test/unit/mocks/tree-vm.ts
@@ -1,0 +1,3 @@
+export class TreeVm {
+
+}

--- a/test/unit/staged.spec.ts
+++ b/test/unit/staged.spec.ts
@@ -1,0 +1,54 @@
+import { StageComponent } from "aurelia-testing";
+import { bootstrap } from "aurelia-bootstrapper";
+
+import { TreeNodeData } from "../../src/au-tree-helpers";
+import { bootstrapPlugin } from "../helper";
+
+const data: TreeNodeData = {
+  name: "Root",
+  children: [
+    { name: "A" },
+    { name: "B" },
+    { name: "C" }
+  ]
+};
+
+describe("the aurelia tree component", () => {
+  it("should render with minimal configuration", async () => {
+    const component = StageComponent
+      .withResources("mocks/tree-vm")
+      .inView(`<div id="test-target">
+          <au-tree-root data.bind="data"></au-tree-root>
+        </div>`)
+      .boundTo({ data });
+
+    bootstrapPlugin(component);
+
+    await component.create(bootstrap);
+
+    expect(component.element.querySelector("au-tree-root")).not.toBeNull();
+    expect(component.element.querySelectorAll("ul li").length).toBe(data.children.length);
+
+    component.dispose();
+  });
+
+  it("should render the nodes name if no node-view-model is provided", async () => {
+    const component = StageComponent
+      .withResources("mocks/tree-vm")
+      .inView(`<div id="test-target">
+          <au-tree-root data.bind="data"></au-tree-root>
+        </div>`)
+      .boundTo({ data });
+
+    bootstrapPlugin(component);
+
+    await component.create(bootstrap);
+
+    expect(component.element.querySelector(".au-tree__root span").innerHTML).toBe(data.name);
+
+    const children = Array.from(component.element.querySelectorAll(".au-tree__node span"));
+    children.forEach((child) => data.children.map(c => c.name).includes(child.innerHTML));
+
+    component.dispose();
+  })
+});

--- a/test/unit/stub.spec.ts
+++ b/test/unit/stub.spec.ts
@@ -1,5 +1,0 @@
-describe("placeholder test", () => {
-  it("should pass", () => {
-    expect(true).toBeTruthy();
-  })
-})


### PR DESCRIPTION
adds the infrastructure to run staged component tests.

Additionally the `<require from="styles.css"></require>` statement from `src/au-tree-root.html` has been removed. The plugin consumer should be able to decide how to bundle/or bundle at all their css files vs having the plugin dictate the usage