### PR TITLE
cross-os-safe moduleNameMapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,8 @@
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "src/index.*": "<rootDir>/src/aurelia-tree.ts",
-      ".*src/styles.css": "<rootDir>/dist/commonjs/styles.css",
-      ".*test/unit/src/(.*)": "<rootDir>/src/$1.ts",
+      "src\\\\index": "<rootDir>/src/aurelia-tree.ts",
+      ".*test\\\\unit\\\\src\\\\(.*)": "<rootDir>/src/$1.ts",
       "(test\\\\unit\\\\)aurelia-(.*)": "<rootDir>/node_modules/aurelia-$2",
       "^.+\\.(css)$": "<rootDir>/test/jest-css-stub.js"
     },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "src\\\\index": "<rootDir>/src/aurelia-tree.ts",
-      ".*test\\\\unit\\\\src\\\\(.*)": "<rootDir>/src/$1.ts",
+      "src(\\\\|/)index": "<rootDir>/src/aurelia-tree.ts",
+      ".*test(\\\\|/)unit(\\\\|/)src(\\\\|/)(.*)": "<rootDir>/src/$4.ts",
       "(test\\\\unit\\\\)aurelia-(.*)": "<rootDir>/node_modules/aurelia-$2",
       "^.+\\.(css)$": "<rootDir>/test/jest-css-stub.js"
     },


### PR DESCRIPTION
This one works on Linux, if you could give it a test-run on Win, it already took me more than half an hour to un-dust my old win10 installation ;)